### PR TITLE
add UseDHLInvoice & DHLInvoiceLanguageCode params

### DIFF
--- a/src/Entity/EU/ShipmentRequest.php
+++ b/src/Entity/EU/ShipmentRequest.php
@@ -115,6 +115,19 @@ class ShipmentRequest extends Base
             'required' => false,
             'subobject' => true,
         ],
+        'UseDHLInvoice' => [
+	        'type' => 'string',
+	        'required' => false,
+	        'subobject' => false,
+	        'enumeration' => 'Y,N',
+        ],
+        'DHLInvoiceLanguageCode' => [
+	        'type' => 'string',
+	        'required' => false,
+	        'subobject' => false,
+	        'comment' => 'ISO Language Code',
+	        'maxLength' => '2',
+        ],
         'DHLInvoiceType' => [
             'type' => 'string',
             'required' => false,


### PR DESCRIPTION
Although these two parameters are optional on their docs, we were still asked to add them in order to get our production access (certification).

I've updated the body_params in order for validation to work for the new fields.

