### PR TITLE
Adding ValueAddedServices datatype to allow for DHL Paperless

### DIFF
--- a/src/Datatype/AM/ValueAddedServices.php
+++ b/src/Datatype/AM/ValueAddedServices.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Mtc\Dhl\Datatype\AM;
+
+use Mtc\Dhl\Datatype\Base;
+
+class ValueAddedServices extends Base
+{
+    /**
+     * Is this object a subobject
+     * @var boolean
+     */
+    protected $isSubobject = true;
+
+    /**
+     * Parameters of the datatype
+     * @var array
+     */
+    protected $params = [
+        'ServiceCode' => [
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'Service Code. Usually WY for paperless invoicing',
+        ],
+    ];
+
+}

--- a/src/Datatype/EU/ValueAddedServices.php
+++ b/src/Datatype/EU/ValueAddedServices.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Mtc\Dhl\Datatype\EU;
+
+class ValueAddedServices extends \Mtc\Dhl\Datatype\AM\ValueAddedServices
+{
+    /**
+     * Parameters of the datatype
+     * @var array
+     */
+    protected $params = [
+        'ServiceCode' => [
+            'type' => 'string',
+            'required' => false,
+            'subobject' => false,
+            'comment' => 'Service Code. Usually WY for paperless invoicing',
+        ],
+    ];
+}

--- a/src/Entity/EU/ShipmentRequest.php
+++ b/src/Entity/EU/ShipmentRequest.php
@@ -100,6 +100,11 @@ class ShipmentRequest extends Base
             'required' => false,
             'subobject' => true,
         ],
+        'ValueAddedServices' => [
+            'type' => 'ValueAddedServices',
+            'required' => false,
+            'subobject' => true,
+        ],
         'Consignee' => [
             'type' => 'Consignee',
             'required' => false,


### PR DESCRIPTION
Adding an optional datatype called ValueAddedServices that contains only one field, that being "ServiceCode"

It is intended to allow for Paperless Invoicing after discussions with an DHL IT team member

This is an optional data field and so shouldn't impact existing users

Thanks
Jack