### PR TITLE
Condition is not always received in TrackingResponse.

### DIFF
--- a/src/Entity/Base.php
+++ b/src/Entity/Base.php
@@ -217,7 +217,7 @@ abstract class Base extends BaseDataType
     {
         $xml = simplexml_load_string(str_replace('req:', '', $xml));
 
-        if ((string)$xml->Response->Status->Condition->ConditionCode != '') {
+        if (isset($xml->Response->Status->Condition) && (string)$xml->Response->Status->Condition->ConditionCode != '') {
             $errorMsg = ((string)$xml->Response->Status->Condition->ConditionCode) . ' : '
                 . ((string)$xml->Response->Status->Condition->ConditionData);
             throw new \Exception('Error returned from DHL webservice : ' . $errorMsg);


### PR DESCRIPTION
AWBInfo > Status > Condition is not present in tracking response.

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<req:TrackingResponse
	xmlns:req="http://www.dhl.com"
	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.dhl.com TrackingResponse.xsd">
	<Response>
		<ServiceHeader>
			<MessageTime>2026-06-26T09:21:14+00:00</MessageTime>
			<MessageReference>reference_28_to_32_chars1234</MessageReference>
			<SiteID>XXX</SiteID>
		</ServiceHeader>
	</Response>
	<AWBInfo>
		<AWBNumber>XXX</AWBNumber>
		<Status>
			<ActionStatus>success</ActionStatus>
		</Status>
		...
	</AWBInfo>
	<LanguageCode>en</LanguageCode>
</req:TrackingResponse>
```
